### PR TITLE
implement `__getstate__` and `__setstate__` for `PySINumber` and `PySIArrayX`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ approx = "0.4"
 lazy_static = "1.4"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3"
 ang = "0.5"
 regex = "1.5"
 pyo3 = { version = "0.15", features = ["multiple-pymethods"], optional = true}

--- a/src/python/angle.rs
+++ b/src/python/angle.rs
@@ -2,7 +2,7 @@ use ang::Angle;
 use pyo3::prelude::*;
 use pyo3::PyNumberProtocol;
 
-#[pyclass(name = "Angle")]
+#[pyclass(name = "Angle", module = "si_units")]
 #[derive(Clone, Copy)]
 pub struct PyAngle(pub(crate) Angle<f64>);
 

--- a/src/python/macros.rs
+++ b/src/python/macros.rs
@@ -21,6 +21,16 @@ macro_rules! impl_array {
 
         #[pymethods]
         impl $struct {
+            fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+                state
+                    .extract::<&PyBytes>(py)
+                    .map(|s| self.0 = deserialize(s.as_bytes()).unwrap())
+            }
+
+            fn __getstate__(&self, py: Python) -> PyObject {
+                PyBytes::new(py, &serialize(&self.0).unwrap()).to_object(py)
+            }
+
             pub fn sqrt(&self) -> Result<Self, QuantityError> {
                 Ok(Self(self.0.sqrt()?))
             }


### PR DESCRIPTION
This allows the python objects to be pickled and sent across different processes, e.g.:

```python
from concurrent.futures import ProcessPoolExecutor
from si_units import *

def f(x):
    return SIArray1.linspace(x,2*x,11)

with ProcessPoolExecutor() as ex:
    result = list(ex.map(f, [KELVIN, BAR, PASCAL]))
result
```
```
[[1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7000000000000002, 1.8, 1.9, 2] K,
 [100000, 110000, 120000, 130000, 140000, 150000, 160000, 170000, 180000, 190000, 200000] Pa,
 [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7000000000000002, 1.8, 1.9, 2] Pa]
```