### PR TITLE
Fix maturin command in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -60,11 +60,11 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2 --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --universal2 --out dist -m si-units/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Install module
         run: |
           pip install si-units --no-index --find-links dist --force-reinstall

--- a/.github/workflows/test_documentation.yml
+++ b/.github/workflows/test_documentation.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Install module
         run: |
           pip install si-units --no-index --find-links dist --force-reinstall

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -41,11 +41,11 @@ jobs:
         uses: messense/maturin-action@main
         with:
           target: x86_64
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Build wheels - universal2
         uses: messense/maturin-action@main
         with:
-          args: --release --universal2 --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --universal2 --out dist -m si-units/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: messense/maturin-action@main
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist -m si-units/Cargo.toml
+          args: --release --out dist -m si-units/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.11,<0.12"]
+requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
Removed the `--no-sdist` maturin option from the workflows.