### PR TITLE
Remove `Unit` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! Calculate pressure of an ideal gas.
 //! ```
-//! # use quantity::si::*;
+//! # use quantity::*;
 //! let temperature = 25.0 * CELSIUS;
 //! let volume = 1.5 * METER.powi(3);
 //! let moles = 75.0 * MOL;
@@ -20,7 +20,7 @@
 //!
 //! Calculate the gravitational pull of the moon on the earth.
 //! ```
-//! # use quantity::si::*;
+//! # use quantity::*;
 //! let mass_earth = 5.9724e24 * KILOGRAM;
 //! let mass_moon = 7.346e22 * KILOGRAM;
 //! let distance = 383.398 * KILO * METER;
@@ -30,8 +30,7 @@
 //!
 //! Calculate the pressure distribution in the atmosphere using the barometric formula.
 //! ```
-//! # use quantity::si::*;
-//! # use quantity::QuantityError;
+//! # use quantity::*;
 //! # fn main() -> Result<(), QuantityError> {
 //! let z = SIArray1::linspace(1.0 * METER, 70.0 * KILO * METER, 10)?;
 //! let g = 9.81 * METER / SECOND.powi(2);
@@ -72,7 +71,7 @@ mod linalg;
 #[cfg(feature = "python")]
 pub mod python;
 mod si;
-use si::*;
+pub use si::*;
 mod si_fmt;
 
 /// Error type used to indicate unit conversion failures.
@@ -133,7 +132,7 @@ impl<F> Quantity<F> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::*;
+    /// # use quantity::*;
     /// # use quantity::QuantityError;
     /// let p = 5.0 * NEWTON/METER.powi(2);
     /// assert!(p.has_unit(&BAR));
@@ -146,7 +145,7 @@ impl<F> Quantity<F> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::PASCAL;
+    /// # use quantity::PASCAL;
     /// # use quantity::QuantityError;
     /// # use approx::assert_relative_eq;
     /// # fn main() -> Result<(), QuantityError> {
@@ -173,7 +172,7 @@ impl<F> Quantity<F> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::PASCAL;
+    /// # use quantity::PASCAL;
     /// # use quantity::QuantityError;
     /// # use approx::{assert_relative_eq, assert_ulps_eq};
     /// # fn main() -> Result<(), QuantityError> {
@@ -200,7 +199,7 @@ impl<F> Quantity<F> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::{BAR, PASCAL};
+    /// # use quantity::{BAR, PASCAL};
     /// # use quantity::QuantityError;
     /// # use approx::{assert_relative_eq, assert_ulps_eq};
     /// # fn main() -> Result<(), QuantityError> {
@@ -579,7 +578,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use approx::assert_relative_eq;
     /// let x = 5.0 * METER;
     /// assert_relative_eq!(x.powi(2), &(25.0 * METER * METER));
@@ -595,7 +594,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use quantity::QuantityError;
     /// # use approx::assert_relative_eq;
     /// # fn main() -> Result<(), QuantityError> {
@@ -616,7 +615,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use quantity::QuantityError;
     /// # use approx::assert_relative_eq;
     /// # fn main() -> Result<(), QuantityError> {
@@ -637,7 +636,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use quantity::QuantityError;
     /// # use approx::assert_relative_eq;
     /// # fn main() -> Result<(), QuantityError> {
@@ -658,7 +657,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::{KILO, PASCAL, BAR, KELVIN};
+    /// # use quantity::{KILO, PASCAL, BAR, KELVIN};
     /// # use quantity::QuantityError;
     /// # use approx::assert_relative_eq;
     /// # fn main() -> Result<(), QuantityError> {
@@ -688,7 +687,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::{KILO, PASCAL, BAR, KELVIN};
+    /// # use quantity::{KILO, PASCAL, BAR, KELVIN};
     /// # use quantity::QuantityError;
     /// # use approx::assert_relative_eq;
     /// # fn main() -> Result<(), QuantityError> {
@@ -718,7 +717,7 @@ impl SINumber {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::KELVIN;
+    /// # use quantity::KELVIN;
     /// # use approx::assert_relative_eq;
     /// let t = -50.0 * KELVIN;
     /// assert_relative_eq!(t.abs(), &(50.0 * KELVIN));
@@ -763,7 +762,7 @@ impl<D: Dimension, S: Data<Elem = f64>> Quantity<ArrayBase<S, D>> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::BAR;
+    /// # use quantity::BAR;
     /// # use quantity::QuantityError;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
@@ -901,7 +900,7 @@ impl<D: Dimension, S: Data<Elem = f64>> Quantity<ArrayBase<S, D>> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
     /// let x = arr1(&[3.0, 5.0]) * METER;
@@ -918,7 +917,7 @@ impl<D: Dimension, S: Data<Elem = f64>> Quantity<ArrayBase<S, D>> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use quantity::QuantityError;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
@@ -939,7 +938,7 @@ impl<D: Dimension, S: Data<Elem = f64>> Quantity<ArrayBase<S, D>> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use quantity::QuantityError;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
@@ -960,7 +959,7 @@ impl<D: Dimension, S: Data<Elem = f64>> Quantity<ArrayBase<S, D>> {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::METER;
+    /// # use quantity::METER;
     /// # use quantity::QuantityError;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
@@ -984,7 +983,7 @@ impl SIArray1 {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::{SIArray1, METER};
+    /// # use quantity::{SIArray1, METER};
     /// # use quantity::QuantityError;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
@@ -1013,7 +1012,7 @@ impl SIArray1 {
     ///
     /// # Example
     /// ```
-    /// # use quantity::si::{SIArray1, METER};
+    /// # use quantity::{SIArray1, METER};
     /// # use quantity::QuantityError;
     /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,12 +1,7 @@
 use super::*;
 
-impl<U: Unit> QuantityArray1<U> {
-    pub fn gradient(
-        &self,
-        dx: QuantityScalar<U>,
-        left: QuantityScalar<U>,
-        right: QuantityScalar<U>,
-    ) -> QuantityArray1<U> {
+impl SIArray1 {
+    pub fn gradient(&self, dx: SINumber, left: SINumber, right: SINumber) -> SIArray1 {
         Quantity {
             value: Array::from_shape_fn(self.raw_dim(), |i| {
                 let d = if i == 0 {
@@ -23,13 +18,8 @@ impl<U: Unit> QuantityArray1<U> {
     }
 }
 
-impl<U: Unit> QuantityArray2<U> {
-    pub fn gradient(
-        &self,
-        dx: QuantityScalar<U>,
-        left: &QuantityArray1<U>,
-        right: &QuantityArray1<U>,
-    ) -> QuantityArray2<U> {
+impl SIArray2 {
+    pub fn gradient(&self, dx: SINumber, left: &SIArray1, right: &SIArray1) -> SIArray2 {
         Quantity {
             value: Array::from_shape_fn(self.raw_dim(), |(c, i)| {
                 let d = if i == 0 {
@@ -46,8 +36,8 @@ impl<U: Unit> QuantityArray2<U> {
     }
 }
 
-impl<S: Data<Elem = f64>, D: Dimension, U: Unit> Quantity<ArrayBase<S, D>, U> {
-    pub fn integrate(&self, weights: &[QuantityArray1<U>]) -> QuantityScalar<U> {
+impl<S: Data<Elem = f64>, D: Dimension> Quantity<ArrayBase<S, D>> {
+    pub fn integrate(&self, weights: &[SIArray1]) -> SINumber {
         assert_eq!(self.value.ndim(), weights.len());
 
         let mut value = self.value.to_owned();
@@ -65,15 +55,15 @@ impl<S: Data<Elem = f64>, D: Dimension, U: Unit> Quantity<ArrayBase<S, D>, U> {
     }
 }
 
-impl<S: Data<Elem = f64>, U: Unit> Quantity<ArrayBase<S, Ix1>, U> {
-    pub fn integrate_trapezoidal(&self, dx: QuantityScalar<U>) -> QuantityScalar<U> {
+impl<S: Data<Elem = f64>> Quantity<ArrayBase<S, Ix1>> {
+    pub fn integrate_trapezoidal(&self, dx: SINumber) -> SINumber {
         let mut weights = Array::ones(self.len());
         weights[0] = 0.5;
         weights[self.len() - 1] = 0.5;
         self.integrate(&[weights * dx])
     }
 
-    pub fn integrate_trapezoidal_cumulative(&self, dx: QuantityScalar<U>) -> QuantityArray1<U> {
+    pub fn integrate_trapezoidal_cumulative(&self, dx: SINumber) -> SIArray1 {
         let mut value = Array::zeros(self.len());
         for i in 1..value.len() {
             value[i] = value[i - 1] + (self.value[i - 1] + self.value[i]) * 0.5;

--- a/src/python/siarray.rs
+++ b/src/python/siarray.rs
@@ -1,6 +1,6 @@
 use super::PyCelsius;
 use crate::si::*;
-use crate::{QuantityError, Unit};
+use crate::{QuantityError, SIArray1, SIArray2, SIArray3, SIArray4};
 use bincode::{deserialize, serialize};
 use ndarray::{arr1, Array};
 use numpy::prelude::*;

--- a/src/python/sinumber.rs
+++ b/src/python/sinumber.rs
@@ -1,5 +1,4 @@
-use crate::si::*;
-use crate::QuantityError;
+use crate::*;
 use bincode::{deserialize, serialize};
 use numpy::prelude::*;
 use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArray3, PyReadonlyArray4};

--- a/src/si_fmt.rs
+++ b/src/si_fmt.rs
@@ -1,5 +1,4 @@
-use super::si::*;
-use ndarray::prelude::*;
+use super::*;
 use regex::Regex;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -139,8 +138,8 @@ impl fmt::Display for SIUnit {
 }
 
 impl SIUnit {
-    pub fn to_latex(&self) -> String {
-        match DERIVED_UNITS.get(self) {
+    pub fn to_latex(self) -> String {
+        match DERIVED_UNITS.get(&self) {
             Some((_, _, _, symbols, exponents)) => unit_to_latex(symbols, exponents, None),
             None => unit_to_latex(&UNIT_SYMBOLS, &self.0, None),
         }
@@ -207,7 +206,7 @@ impl fmt::Display for Debye {
 }
 
 impl Debye {
-    pub fn to_latex(&self) -> String {
+    pub fn to_latex(self) -> String {
         format!("{}\\,\\mathrm{{De}}", float_to_latex(self.0))
     }
 }


### PR DESCRIPTION
The `Unit` trait is an unnecessary complication which nobody uses outside of the standard implementation of SI units.