### PR TITLE
Improve error message in Python when passing an argument without unit

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -58,9 +58,14 @@ where
     Self: PrintUnit,
 {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let (value, unit_from) = ob
-            .call_method0("__getnewargs__")?
-            .extract::<(f64, [i8; 7])>()?;
+        let Ok(raw) = ob.call_method0("__getnewargs__") else {
+            return Err(PyErr::new::<PyValueError, _>(format!(
+                "Missing units! Expected {}, got {}.",
+                Self::UNIT,
+                ob.call_method0("__repr__")?
+            )));
+        };
+        let (value, unit_from) = raw.extract::<(f64, [i8; 7])>()?;
         let unit_into = [L::I8, M::I8, T::I8, I::I8, N::I8, THETA::I8, J::I8];
         if unit_into == unit_from {
             Ok(Quantity(value, PhantomData))
@@ -89,9 +94,14 @@ where
     Self: PrintUnit,
 {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let (value, unit_from) = ob
-            .call_method0("__getnewargs__")?
-            .extract::<(PyReadonlyArray<f64, D>, [i8; 7])>()?;
+        let Ok(raw) = ob.call_method0("__getnewargs__") else {
+            return Err(PyErr::new::<PyValueError, _>(format!(
+                "Missing units! Expected {}, got {}.",
+                Self::UNIT,
+                ob.call_method0("__repr__")?
+            )));
+        };
+        let (value, unit_from) = raw.extract::<(PyReadonlyArray<f64, D>, [i8; 7])>()?;
         let value = value.as_array().to_owned();
         let unit_into = [L::I8, M::I8, T::I8, I::I8, N::I8, THETA::I8, J::I8];
         if unit_into == unit_from {

--- a/src/python.rs
+++ b/src/python.rs
@@ -58,14 +58,16 @@ where
     Self: PrintUnit,
 {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let Ok(raw) = ob.call_method0("__getnewargs__") else {
+        let Ok((value, unit_from)) = ob
+            .call_method0("__getnewargs__")
+            .and_then(|raw| raw.extract::<(f64, [i8; 7])>())
+        else {
             return Err(PyErr::new::<PyValueError, _>(format!(
                 "Missing units! Expected {}, got {}.",
                 Self::UNIT,
                 ob.call_method0("__repr__")?
             )));
         };
-        let (value, unit_from) = raw.extract::<(f64, [i8; 7])>()?;
         let unit_into = [L::I8, M::I8, T::I8, I::I8, N::I8, THETA::I8, J::I8];
         if unit_into == unit_from {
             Ok(Quantity(value, PhantomData))
@@ -94,14 +96,16 @@ where
     Self: PrintUnit,
 {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let Ok(raw) = ob.call_method0("__getnewargs__") else {
+        let Ok((value, unit_from)) = ob
+            .call_method0("__getnewargs__")
+            .and_then(|raw| raw.extract::<(PyReadonlyArray<f64, D>, [i8; 7])>())
+        else {
             return Err(PyErr::new::<PyValueError, _>(format!(
                 "Missing units! Expected {}, got {}.",
                 Self::UNIT,
                 ob.call_method0("__repr__")?
             )));
         };
-        let (value, unit_from) = raw.extract::<(PyReadonlyArray<f64, D>, [i8; 7])>()?;
         let value = value.as_array().to_owned();
         let unit_into = [L::I8, M::I8, T::I8, I::I8, N::I8, THETA::I8, J::I8];
         if unit_into == unit_from {


### PR DESCRIPTION
```python
from extend_quantity import ideal_gas
ideal_gas(1, 2, 3)
```
```
ValueError                                Traceback (most recent call last)
Input In [2], in <module>
----> 1 ideal_gas(1, 2, 23)

ValueError: Missing units! Expected K, got 1.
```