### PR TITLE
Hide non-essential dependencies behind features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,5 +20,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: cargo build --release --features "${{ matrix.features }}"
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Run tests
-        run: cargo test --release --features "${{ matrix.features }}"
+        run: cargo test --release --features "ndarray approx"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["", "ndarray", "approx", "ndarray approx", "python", "python_numpy", "num-dual"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: cargo build --release --features ${{ matrix.features }}
+        run: cargo build --release --features "${{ matrix.features }}"
       - name: Run tests
-        run: cargo test --release --features ${{ matrix.features }}
+        run: cargo test --release --features "${{ matrix.features }}"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --features ${{ matrix.features }}
       - name: Run tests
-        run: cargo test --release
+        run: cargo test --release --features ${{ matrix.features }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Build and test Rust crate
 
 on:
   push:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,4 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
+        run: cargo test --release --features approx
+  test_array:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests (ndarray)
         run: cargo test --release --features "ndarray approx"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests
         run: cargo test --release --features approx
-  test_array:
+  test_ndarray:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,15 @@ exclude = ["/.github/*", "*.ipynb", "/docs"]
 rustdoc-args = ["--html-in-header", "./src/docs-header.html"]
 
 [dependencies]
-ndarray = { version = "0.16", features = ["approx"] }
-approx = "0.5"
-num-traits = "0.2"
 typenum = "1.17"
+ndarray = { version = "0.16", optional = true}
+approx = { version = "0.5", optional = true }
 pyo3 = { version = "0.22", optional = true }
 numpy = { version = "0.22", optional = true }
 num-dual = { version = "0.10", optional = true }
 
 [features]
 default = []
-python = ["pyo3", "numpy"]
+python = ["pyo3"]
+python_numpy = ["python", "numpy", "ndarray"]
+approx = ["dep:approx", "ndarray?/approx"]

--- a/example/extend_quantity/Cargo.toml
+++ b/example/extend_quantity/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.22.0", features = ["extension-module", "abi3-py39"] }
-quantity = { version = "*", path = "../../", features = ["python"] }
+quantity = { version = "*", path = "../../", features = ["python_numpy"] }
 ndarray = "0.16"

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[cfg(feature = "ndarray")]
 use ndarray::{Array, Dimension};
 use std::collections::HashMap;
 use std::fmt;
@@ -35,7 +36,7 @@ impl<
     }
 }
 
-#[cfg(feature = "python")]
+#[cfg(feature = "pyo3")]
 pub(crate) trait PrintUnit {
     const UNIT: &'static str;
 }
@@ -64,6 +65,7 @@ macro_rules! impl_fmt {
             }
         }
 
+        #[cfg(feature = "ndarray")]
         impl<D: Dimension> fmt::Display
             for Quantity<Array<f64, D>, SIUnit<$t, $l, $m, $i, $theta, $n, Z0>>
         {
@@ -179,6 +181,7 @@ static PREFIX_SYMBOLS: LazyLock<HashMap<i8, &'static str>> = LazyLock::new(|| {
 #[cfg(test)]
 mod tests {
     use crate::*;
+    #[cfg(feature = "ndarray")]
     use ndarray::arr1;
 
     #[test]
@@ -193,6 +196,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ndarray")]
     fn test_fmt_arr() {
         assert_eq!(
             format!("{}", arr1(&[273.15, 323.15]) * KELVIN),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,12 +136,13 @@
 //! ```
 
 #![warn(clippy::all)]
+#[cfg(feature = "ndarray")]
 use ndarray::{Array, ArrayBase, Data, Dimension};
-use num_traits::Zero;
 use std::marker::PhantomData;
 use std::ops::{Div, Mul};
 use typenum::{ATerm, Diff, Integer, Negate, Quot, Sum, TArr, N1, N2, P1, P3, Z0};
 
+#[cfg(feature = "ndarray")]
 mod array;
 mod fmt;
 mod ops;
@@ -399,6 +400,7 @@ impl Mul<CELSIUS> for f64 {
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<S: Data<Elem = f64>, D: Dimension> Mul<CELSIUS> for ArrayBase<S, D> {
     type Output = Temperature<Array<f64, D>>;
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -415,6 +417,7 @@ impl Div<CELSIUS> for Temperature<f64> {
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<D: Dimension> Div<CELSIUS> for Temperature<Array<f64, D>> {
     type Output = Array<f64, D>;
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -451,16 +454,6 @@ impl<T, U> Quantity<T, U> {
         T: Div<T2>,
     {
         self.0 / unit.0
-    }
-}
-
-impl<U> Zero for Quantity<f64, U> {
-    fn zero() -> Self {
-        Quantity(0.0, PhantomData)
-    }
-
-    fn is_zero(&self) -> bool {
-        self.0.is_zero()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,8 @@
 //! Calculate the pressure distribution in the atmosphere using the barometric formula.
 //! Array operations require the `ndarray` feature.
 //! ```
-//! #![cfg(feature = "ndarray")]
+//! # #[cfg(feature = "ndarray")]
+//! # {
 //! # use quantity::*;
 //! # use typenum::P2;
 //! let z = Length::linspace(1.0 * METER, 70.0 * KILO * METER, 10);
@@ -135,6 +136,7 @@
 //! // z = 54.44467 km   p = 140.51557  Pa
 //! // z = 62.22233 km   p =  54.98750  Pa
 //! // z = 70.00000 km   p =  21.51808  Pa
+//! # }
 //! ```
 
 #![warn(clippy::all)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,9 @@
 //! ```
 //!
 //! Calculate the pressure distribution in the atmosphere using the barometric formula.
+//! Array operations require the `ndarray` feature.
 //! ```
+//! #![cfg(feature = "ndarray")]
 //! # use quantity::*;
 //! # use typenum::P2;
 //! let z = Length::linspace(1.0 * METER, 70.0 * KILO * METER, 10);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,5 +1,7 @@
 use super::Quantity;
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq};
+#[cfg(feature = "ndarray")]
 use ndarray::{Array, ArrayBase, Data, DataMut, DataOwned, Dimension};
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -77,6 +79,7 @@ where
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<U, S: Data<Elem = f64>, D: Dimension> Mul<Quantity<f64, U>> for &ArrayBase<S, D> {
     type Output = Quantity<Array<f64, D>, U>;
     fn mul(self, other: Quantity<f64, U>) -> Self::Output {
@@ -84,6 +87,7 @@ impl<U, S: Data<Elem = f64>, D: Dimension> Mul<Quantity<f64, U>> for &ArrayBase<
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<U, S: DataOwned<Elem = f64> + DataMut, D: Dimension> Mul<Quantity<f64, U>>
     for ArrayBase<S, D>
 {
@@ -175,6 +179,7 @@ where
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<U: Neg, S: Data<Elem = f64>, D: Dimension> Div<Quantity<f64, U>> for &ArrayBase<S, D> {
     type Output = Quantity<Array<f64, D>, Negate<U>>;
     fn div(self, other: Quantity<f64, U>) -> Self::Output {
@@ -182,6 +187,7 @@ impl<U: Neg, S: Data<Elem = f64>, D: Dimension> Div<Quantity<f64, U>> for &Array
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<U: Neg, S: DataOwned<Elem = f64> + DataMut, D: Dimension> Div<Quantity<f64, U>>
     for ArrayBase<S, D>
 {
@@ -479,6 +485,7 @@ impl<T: PartialOrd, U> PartialOrd for Quantity<T, U> {
     }
 }
 
+#[cfg(feature = "approx")]
 impl<T: AbsDiffEq, U> AbsDiffEq for Quantity<T, U> {
     type Epsilon = T::Epsilon;
 
@@ -491,6 +498,7 @@ impl<T: AbsDiffEq, U> AbsDiffEq for Quantity<T, U> {
     }
 }
 
+#[cfg(feature = "approx")]
 impl<T: RelativeEq, U> RelativeEq for Quantity<T, U> {
     fn default_max_relative() -> Self::Epsilon {
         T::default_max_relative()

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -341,7 +341,6 @@ impl<U> Quantity<f64, U> {
     /// # Example
     /// ```
     /// # use quantity::METER;
-    /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
     /// # use typenum::P2;
     /// let x = 3.0 * METER;
@@ -359,7 +358,6 @@ impl<U> Quantity<f64, U> {
     /// # Example
     /// ```
     /// # use quantity::METER;
-    /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
     /// let x = 9.0 * METER * METER;
     /// assert_relative_eq!(x.sqrt(), 3.0 * METER);
@@ -376,7 +374,6 @@ impl<U> Quantity<f64, U> {
     /// # Example
     /// ```
     /// # use quantity::METER;
-    /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
     /// let x = 27.0 * METER * METER * METER;
     /// assert_relative_eq!(x.cbrt(), 3.0 * METER);
@@ -393,7 +390,6 @@ impl<U> Quantity<f64, U> {
     /// # Example
     /// ```
     /// # use quantity::METER;
-    /// # use ndarray::arr1;
     /// # use approx::assert_relative_eq;
     /// # use typenum::P4;
     /// let x = 81.0 * METER * METER * METER * METER;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,7 +1,8 @@
-use crate::fmt::PrintUnit;
-
 use super::{Quantity, SIUnit};
+use crate::fmt::PrintUnit;
+#[cfg(feature = "ndarray")]
 use ndarray::{Array, Dimension};
+#[cfg(feature = "ndarray")]
 use numpy::{IntoPyArray, PyReadonlyArray};
 use pyo3::{exceptions::PyValueError, prelude::*};
 use std::{marker::PhantomData, sync::LazyLock};
@@ -26,6 +27,7 @@ impl<T: Integer, L: Integer, M: Integer, I: Integer, THETA: Integer, N: Integer,
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<
         T: Integer,
         L: Integer,
@@ -74,6 +76,7 @@ where
     }
 }
 
+#[cfg(feature = "ndarray")]
 impl<
         'py,
         T: Integer,


### PR DESCRIPTION
No need to depend on ndarray for dependents that only use scalar quantities.