### PR TITLE
Revert SIArray1 interfaces

### DIFF
--- a/si-units/src/lib.rs
+++ b/si-units/src/lib.rs
@@ -326,9 +326,7 @@ struct SIArray1;
 
 #[pymethods]
 impl SIArray1 {
-    #[staticmethod]
-    #[expect(clippy::new_ret_no_self)]
-    fn new(value: Bound<'_, PyAny>) -> PyResult<Bound<'_, PySIObject>> {
+    fn __call__<'py>(&self, value: Bound<'py, PyAny>) -> PyResult<Bound<'py, PySIObject>> {
         let py = value.py();
         if let Ok(v) = value.extract::<SINumber>() {
             let value = arr1(&[1.0]) * v.value;
@@ -508,7 +506,7 @@ pub fn si_units(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<PySIObject>()?;
     m.add_class::<PyAngle>()?;
-    m.add_class::<SIArray1>()?;
+    m.add("SIArray1", SIArray1)?;
 
     add_constant(m, "SECOND", 1.0, _SECOND)?;
     add_constant(m, "METER", 1.0, _METER)?;


### PR DESCRIPTION
Some trickery to achieve
```python
arr = SIArray1(5*KELVIN)
arr = SIArray1([5*CELSIUS, 20*KELVIN])
arr = SIArray1.linspace(0*CELSIUS, 100*CELSIUS, 10)
arr = SIArray1.logspace(PASCAL, BAR, 6)
```