### PR TITLE
Updates to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,38 +64,12 @@ for i in 0..10 {
 // z = 70.00000 km   p =  21.51808  Pa
 ```
 
+## Python Package
+
+For information on how to install, use and build the Python package, see [here](si-units).
+
 ## Documentation
 
 For the rust documentation, see [here](https://docs.rs/quantity).
 
 For the python documentation, see [here](https://itt-ustutt.github.io/quantity/index.html).
-
-## Development
-
-To build the project including the bindings to python, we use [maturin](https://github.com/PyO3/maturin).
-
-When developing, use
-
-```
-maturin develop --release
-```
-
-To build the python wheels, use
-
-```
-maturin build --release
-```
-
-To build the documentation you need `sphinx` and some additional packages. From the root directory, type
-
-```
-cd si-units/docs
-make html
-```
-
-To run the doctests, from the root directory, type
-
-```
-cd si-units/docs
-make doctest
-```

--- a/si-units/README.md
+++ b/si-units/README.md
@@ -10,17 +10,15 @@ In addition to simple scalar quantities, it can be used to decorate any complex 
 
 ## Installation and Usage
 
-You can install the python package from source (you need a rust compiler for that):
-
-```
-pip install git+https://github.com/itt-ustutt/quantity
-```
-
-or get the compiled files from PyPI
+You can install the package from PyPI
 
 ```
 pip install si-units
 ```
+
+For the documentation, see [here](https://itt-ustutt.github.io/quantity/index.html).
+
+To build the wheel or documentation locally, see below.
 
 ## Examples
 
@@ -45,6 +43,42 @@ sqms = ms**2
 print(sqms) # [4, 9, 16] m²
 ```
 
-## Documentation
+## Building from Source
 
-For the documentation, see [here](https://itt-ustutt.github.io/quantity/index.html).
+You need a rust compiler to build the wheel locally.
+To build the bindings to python, we use [maturin](https://github.com/PyO3/maturin).
+
+Use
+
+``` bash
+# in si-units
+maturin develop --release
+```
+
+to build the package locally.
+
+To build the python wheels, use
+
+```bash
+maturin build --release
+```
+
+## Building the Documentation
+
+To build the documentation you need `mkdocs-material` and `mkdocstrings-python`. Installing these packages (e.g. using `uv` or `pip`) will also install the needed dependencies. 
+During development, use
+
+```bash
+# in si-units
+mkdocs serve
+```
+
+to run a local development server.
+
+To build the documentation for deployment, use
+
+```bash
+# in si-units
+mkdocs build
+```
+


### PR DESCRIPTION
Move instructions for locally building the Python package and documentation to `si-units/README.md` 