### PR TITLE
Implement Deref for dimensionless quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Implemented `Deref` for `Dimensionless<T>`. [#86](https://github.com/itt-ustutt/quantity/pull/86)
 
 ## [0.10.2] - 2025-04-09
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@
 #[cfg(feature = "ndarray")]
 use ndarray::{Array, ArrayBase, Data, Dimension};
 use std::marker::PhantomData;
-use std::ops::{Div, Mul};
+use std::ops::{Deref, Div, Mul};
 use typenum::{ATerm, Diff, Integer, Negate, Quot, Sum, TArr, N1, N2, P1, P3, Z0};
 
 #[cfg(feature = "ndarray")]
@@ -503,6 +503,14 @@ impl<T, U> Quantity<T, U> {
     }
 }
 
+impl<T> Deref for Dimensionless<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[cfg(feature = "num-dual")]
 mod num_dual {
     use super::Quantity;
@@ -520,5 +528,17 @@ mod num_dual {
         fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
             Quantity::new(self.0.lift())
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_deref() {
+        let pressure = 1.0135 * BAR;
+        let x = (pressure / PASCAL).ln();
+        assert_eq!(x, 1.0135e5_f64.ln())
     }
 }


### PR DESCRIPTION
This allows, e.g., to call every method of `f64` on an object of type `Dimensionless<f64>`.