### PR TITLE
Add some new units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.3] - 2025-05-07
 ### Added
 - Implemented `Deref` for `Dimensionless<T>`. [#86](https://github.com/itt-ustutt/quantity/pull/86)
+- Added the new type aliases `MassFlux`, `HeatFlux`, `ThermalTransmittance`, and `ThermalResistance`. [#87](https://github.com/itt-ustutt/quantity/pull/87)
 
 ## [0.10.2] - 2025-04-09
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quantity"
-version = "0.10.2"
+version = "0.10.3"
 authors = [
     "Philipp Rehner <prehner@ethz.ch>",
     "Gernot Bauer <bauer@itt.uni-stuttgart.de>",

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -119,6 +119,7 @@ const KG: Mass = KILOGRAM;
 const JMK: MolarEntropy = Quantity(1.0, PhantomData);
 const JKGK: SpecificEntropy = Quantity(1.0, PhantomData);
 const WMK: ThermalConductivity = Quantity(1.0, PhantomData);
+const GS: MassFlowRate = Quantity(1e-3, PhantomData);
 
 impl_fmt!(Z0, N3, Z0, Z0, Z0, P1, MOL / M3, "mol/m³", Some(MEGA));
 impl_fmt!(Z0, N2, Z0, Z0, Z0, P1, MOL / M2, "mol/m²", Some(MEGA));
@@ -142,6 +143,10 @@ impl_fmt!(Z0, P2, Z0, Z0, Z0, Z0, M2, "m²", None);
 impl_fmt!(Z0, P3, Z0, Z0, Z0, Z0, M3, "m³", None);
 impl_fmt!(N1, P3, N1, Z0, Z0, Z0, M3 / KG / SECOND, "m³/kg/s²", None);
 impl_fmt!(N3, P2, P1, Z0, N1, Z0, WATT / KELVIN, "W/K", None);
+impl_fmt!(N3, Z0, P1, Z0, N1, Z0, WMK / METER, "W/m²/K", None);
+impl_fmt!(N3, Z0, P1, Z0, Z0, Z0, WATT / M2, "W/m²", None);
+impl_fmt!(N1, Z0, P1, Z0, Z0, Z0, GS, "g/s", Some(MEGA));
+impl_fmt!(N1, N2, P1, Z0, Z0, Z0, GS / M2, "g/m²/s", Some(MEGA));
 
 fn get_prefix(value: f64, has_prefix: Option<f64>) -> (f64, &'static str) {
     if let Some(p) = has_prefix {
@@ -194,6 +199,15 @@ mod tests {
     #[test]
     fn test_fmt_si() {
         assert_eq!(format!("{:.3}", RGAS), "8.314  J/mol/K");
+    }
+
+    #[test]
+    fn test_fmt_kg() {
+        let m = 5.0 * KILOGRAM;
+        let t = 4.0 * SECOND;
+        let a = 0.5 * METER * METER;
+        assert_eq!(format!("{:.3}", m / t), "1.250 kg/s");
+        assert_eq!(format!("{:.3}", m / t / a), "2.500 kg/m²/s");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,10 @@ pub type _MassFlowRate = Diff<_Mass, _Time>;
 pub type MassFlowRate<T = f64> = Quantity<T, _MassFlowRate>;
 pub type _MoleFlowRate = Diff<_Moles, _Time>;
 pub type MoleFlowRate<T = f64> = Quantity<T, _MoleFlowRate>;
+pub type _MassFlux = Diff<_MassFlowRate, _Area>;
+pub type MassFlux<T = f64> = Quantity<T, _MassFlux>;
+pub type _HeatFlux = Diff<_Power, _Area>;
+pub type HeatFlux<T = f64> = Quantity<T, _HeatFlux>;
 
 pub type _Viscosity = Sum<_Pressure, _Time>;
 pub type Viscosity<T = f64> = Quantity<T, _Viscosity>;
@@ -259,6 +263,10 @@ pub type _Diffusivity = Sum<_Velocity, _Length>;
 pub type Diffusivity<T = f64> = Quantity<T, _Diffusivity>;
 pub type _ThermalConductivity = Diff<_Power, Sum<_Length, _Temperature>>;
 pub type ThermalConductivity<T = f64> = Quantity<T, _ThermalConductivity>;
+pub type _ThermalTransmittance = Diff<_Power, Sum<_Area, _Temperature>>;
+pub type ThermalTransmittance<T = f64> = Quantity<T, _ThermalTransmittance>;
+pub type _ThermalResistance = Negate<_ThermalTransmittance>;
+pub type ThermalResistance<T = f64> = Quantity<T, _ThermalResistance>;
 pub type _SurfaceTension = Diff<_Force, _Length>;
 pub type SurfaceTension<T = f64> = Quantity<T, _SurfaceTension>;
 


### PR DESCRIPTION
Adds the new type aliases `MassFlux`, `HeatFlux`, `ThermalTransmittance`, and `ThermalResistance`.

Note that this is just for convenience. It is always possible to define type aliases in other crates or use the definition of the unit directly in interfaces.