### PR TITLE
Update to pyo3=0.25 and numpy=0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ document-features = "0.2"
 ## Use N-dimensional arrays from the [ndarray] crate as value of a quantity.
 ndarray = { version = "0.16", optional = true }
 approx = { version = "0.5", optional = true }
-pyo3 = { version = "0.23", optional = true }
-numpy = { version = "0.23", optional = true }
+pyo3 = { version = "0.25", optional = true }
+numpy = { version = "0.25", optional = true }
 ## Use generalized (hyper-)dual numbers from the [num-dual] crate as value of a quantity.
-num-dual = { version = "0.11.1", optional = true }
+# num-dual = { version = "0.11.1", optional = true }
+num-dual = { git = "https://github.com/itt-ustutt/num-dual", branch = "pyo3_0.25", optional = true }
 
 [features]
 default = []

--- a/example/extend_quantity/Cargo.toml
+++ b/example/extend_quantity/Cargo.toml
@@ -8,6 +8,6 @@ name = "extend_quantity"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39"] }
 quantity = { version = "*", path = "../../", features = ["python_numpy"] }
 ndarray = "0.16"

--- a/si-units/Cargo.toml
+++ b/si-units/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ndarray = "0.16"
-numpy = "0.23"
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py39"] }
+numpy = "0.25"
+pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39"] }
 regex = "1.11"
 thiserror = "2.0"


### PR DESCRIPTION
Requires release of `num-dual` and change to Cargo.toml which currently refers to the updated git branch.