### PR TITLE
Generalize index to allow for, e.g., multidimensional slicing

### DIFF
--- a/si-units/CHANGELOG.md
+++ b/si-units/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Generalized indexing, such that, e.g., general multidimensional slicing operations are possible for quantities containing NumPy arrays. [#110](https://github.com/itt-ustutt/quantity/pull/110)
 
 ## [0.11.3] - 2026-04-22
 ### Added

--- a/si-units/src/lib.rs
+++ b/si-units/src/lib.rs
@@ -272,15 +272,15 @@ impl PySIObject {
             .and_then(|v| v.extract::<usize>(py))
     }
 
-    fn __getitem__(&self, py: Python, idx: isize) -> PyResult<Self> {
+    fn __getitem__(&self, py: Python, idx: &Bound<'_, PyAny>) -> PyResult<Self> {
         let value = self.value.call_method1(py, "__getitem__", (idx,))?;
         Ok(Self::new(value, self.unit))
     }
 
-    fn __setitem__(&self, py: Python, idx: isize, value: SINumber) -> PyResult<()> {
+    fn __setitem__(&self, py: Python, idx: &Bound<'_, PyAny>, value: &Self) -> PyResult<()> {
         if self.unit == value.unit {
             self.value
-                .call_method1(py, "__setitem__", (idx, value.value))?;
+                .call_method1(py, "__setitem__", (idx, &value.value))?;
             Ok(())
         } else {
             Err(QuantityError::InconsistentUnits {


### PR DESCRIPTION
```python
t = si.linspace(0*si.KELVIN, 100*si.KELVIN, 11)
t[2:3] = si.array([5*si.KELVIN]*2)
t
```
```
array([  0.,  10.,   5.,   5.,  40.,  50.,  60.,  70.,  80.,  90., 100.]) K
```