### PR TITLE
Added `sum` to `SIObject`

### DIFF
--- a/si-units/CHANGELOG.md
+++ b/si-units/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `ATM` and `POISE` as additional units for pressure and viscosity.
+- Added `sum` for `SIObject`s that can be summed. [#111](https://github.com/itt-ustutt/quantity/pull/111)
 
 ### Fixed
 - Fixed the String representation of non-scalar mass quantities. [#111](https://github.com/itt-ustutt/quantity/pull/111)

--- a/si-units/src/lib.rs
+++ b/si-units/src/lib.rs
@@ -297,6 +297,11 @@ impl PySIObject {
         }
     }
 
+    fn sum(&self, py: Python) -> PyResult<Self> {
+        let value = self.value.call_method0(py, "sum")?;
+        Ok(Self::new(value, self.unit))
+    }
+
     #[getter]
     fn unit(&self) -> [i8; 7] {
         self.unit.0


### PR DESCRIPTION
```python
si.linspace(100*si.GRAM, si.KILOGRAM,10).sum()
```
```
5.5 kg
```
Of course there are many similar methods that we might want to make available for quantities, but the sum might be a particularly relevant one.